### PR TITLE
feat: export FileEntry interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 import type { EventEmitter } from "node:events";
 
-interface FileEntry {
+type FileEntry = {
   path: string;
   original: boolean;
   mime: string;
-}
+} & Record<string, unknown>;
 
 interface CommonDocObject {
   idIstex: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 import type { EventEmitter } from "node:events";
 
-type FileEntry = {
+export interface FileEntry {
   path: string;
   original: boolean;
   mime: string;
-} & Record<string, unknown>;
+}
 
 interface CommonDocObject {
   idIstex: string;


### PR DESCRIPTION
FileEntry devient un type pour associer un Record<string, unknown> afin de rendre les attributs inconnus possibles dans un programme TypeScript.

Exemples: attribut "original" qui peut être présent, attribut "checksum" expérimental pour IALAC...